### PR TITLE
fix: remove margin of the button

### DIFF
--- a/src/assets/css/base.scss
+++ b/src/assets/css/base.scss
@@ -16,6 +16,7 @@ button {
 	border: none;
 	padding: 0;
 	cursor: pointer;
+	margin: 0 auto;
 }
 .container {
 	height: calc(100vh - 26px);


### PR DESCRIPTION
In Safari, HTML tag <button> will have default border
Comparing to other browser,it will resize the button and make it display differently
So I remove the margin of the button, make it look like the same  in every browser